### PR TITLE
Apache template cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,7 @@ default['rundeck']['default_role'] = "user"
 default['rundeck']['hostname'] = "rundeck.#{node['domain']}"
 default['rundeck']['email'] = "rundeck@#{node['domain']}"
 default['rundeck']['restart_on_config_change'] = false
+default['rundeck']['apache-template']['cookbook'] = "rundeck"
 
 # SMTP settings for rundeck notification emails
 default['rundeck']['mail']['enable'] = false

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -186,6 +186,7 @@ end
 template "apache-config" do
   path "#{node['apache']['dir']}/sites-available/rundeck.conf"
   source "rundeck.conf.erb"
+  cookbook node['rundeck']['apache-template']['cookbook']
   mode 00644
   owner "root"
   group "root"


### PR DESCRIPTION
Added the ability to change the location of the apache-config template to another cookbook, in case a different apache config template is needed.   Personally, I needed to enhance the ServerAlias directive and that was not in the current template.  I could have just added ServerAlias, but I also know how complex an apache config can get. 
