### PR TITLE
chef-rundeck recipe uses runit_service but doesn't include runit recipe

### DIFF
--- a/recipes/chef-rundeck.rb
+++ b/recipes/chef-rundeck.rb
@@ -19,6 +19,7 @@
 
 require 'json'
 
+include_recipe 'runit::default'
 include_recipe 'rundeck::default'
 
 rundeck_secure = data_bag_item('rundeck', 'secure')
@@ -26,7 +27,7 @@ rundeck_secure = data_bag_item('rundeck', 'secure')
 if !node['rundeck']['secret_file'].nil? then
   rundeck_secret = Chef::EncryptedDataBagItem.load_secret(node['rundeck']['secret_file'])
   rundeck_secure = Chef::EncryptedDataBagItem.load('rundeck', 'secure', rundeck_secret)
-end  
+end
 
 
 bags = data_bag('rundeck_projects')


### PR DESCRIPTION
The recipe assumes runit is installed already, which may not be the case.
