### PR TITLE
Full path to chef-rundeck is required

### DIFF
--- a/templates/default/sv-chef-rundeck-run.erb
+++ b/templates/default/sv-chef-rundeck-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
 exec \
-chpst -u <%=@options[:user]%> chef-rundeck -c <%=@options[:chef_config]%> -f <%=@options[:project_config]%> -w <%=@options[:chef_webui_url]%> -o <%=@options[:chef_rundeck_host]%> -p <%=@options[:chef_rundeck_port]%> <% if @options[:chef_rundeck_partial_search] %>--partial-search true<% end %>
+chpst -u <%=@options[:user]%> /opt/chef/embedded/bin/chef-rundeck -c <%=@options[:chef_config]%> -f <%=@options[:project_config]%> -w <%=@options[:chef_webui_url]%> -o <%=@options[:chef_rundeck_host]%> -p <%=@options[:chef_rundeck_port]%> <% if @options[:chef_rundeck_partial_search] %>--partial-search true<% end %>


### PR DESCRIPTION
Since chef-rundeck is now installed via chef_gem, chef-rundeck is unlikely to be in PATH given it will be under /opt/chef/embedded/bin/. Specifying full path /opt/chef/embedded/bin/chef-rundeck in the runit service config.
