### PR TITLE
Added attribute for client name to use with chef integration.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ default['rundeck']['chef_rundeck_partial_search'] = false
 default['rundeck']['user'] = "rundeck"
 default['rundeck']['user_home'] = "/home/rundeck"
 default['rundeck']['chef_config'] = "/etc/chef/rundeck.rb"
+default['rundeck']['chef_client_name'] = "chef-rundeck"
 default['rundeck']['chef_rundeck_url'] = "http://chef.#{node['domain']}:#{node['rundeck']['chef_rundeck_port']}"
 default['rundeck']['chef_webui_url'] = "https://chef.#{node['domain']}"
 default['rundeck']['chef_url'] = "https://chef.#{node['domain']}"

--- a/templates/default/rundeck.rb.erb
+++ b/templates/default/rundeck.rb.erb
@@ -1,8 +1,8 @@
 log_level                :info
 log_location             STDOUT
-node_name                'rundeck'
+node_name                '<%=@rundeck[:chef_client_name]%>'
 client_key               '/etc/chef/rundeck.pem'
 validation_client_name   'chef-validator'
 validation_key           '/etc/chef/validation.pem'
-chef_server_url          '<%=@rundeck[:chef_url]%>'  
+chef_server_url          '<%=@rundeck[:chef_url]%>'
 cache_type               'BasicFile'


### PR DESCRIPTION
README.md shows Chef client creation for chef-rundeck using "chef-rundeck" as client name, but name written to the config file is "rundeck". Someone following the README would then find chef-rundeck failing to authenticate with the Chef server due to mis-matched client names.
