### PR TITLE
Unix node recipe uses 'user_home' attribute rather than 'basedir' 

### DIFF
--- a/recipes/node_unix.rb
+++ b/recipes/node_unix.rb
@@ -23,29 +23,29 @@ rundeck_secure = data_bag_item('rundeck', 'secure')
 if !node['rundeck']['secret_file'].nil? then
   rundeck_secret = Chef::EncryptedDataBagItem.load_secret(node['rundeck']['secret_file'])
   rundeck_secure = Chef::EncryptedDataBagItem.load('rundeck', 'secure', rundeck_secret)
-end  
+end
 
 user node['rundeck']['user'] do
   system true
   shell "/bin/bash"
-  home node['rundeck']['basedir']
+  home node['rundeck']['user_home']
 end
 
-directory node['rundeck']['basedir'] do
+directory node['rundeck']['user_home'] do
   owner node['rundeck']['user']
   group node['rundeck']['user']
   recursive true
   mode 00700
 end
 
-directory "#{node['rundeck']['basedir']}/.ssh" do
+directory "#{node['rundeck']['user_home']}/.ssh" do
   owner node['rundeck']['user']
   group node['rundeck']['user']
   recursive true
   mode 00700
 end
 
-file "#{node['rundeck']['basedir']}/.ssh/authorized_keys" do
+file "#{node['rundeck']['user_home']}/.ssh/authorized_keys" do
   owner node['rundeck']['user']
   group node['rundeck']['user']
   mode 00600


### PR DESCRIPTION
Updates node_unix recipe to use the user_home attribute attribute for the rundeck user's home directory (rather than basedir), as the documentation describes.
