### PR TITLE
Add node_unix support for Mac OS X

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default['rundeck']['chef_rundeck_port'] = 9980
 default['rundeck']['chef_rundeck_host'] = "0.0.0.0"
 default['rundeck']['chef_rundeck_partial_search'] = false
 default['rundeck']['user'] = "rundeck"
+default['rundeck']['group'] = node['rundeck']['user']
 default['rundeck']['user_home'] = "/home/rundeck"
 default['rundeck']['chef_config'] = "/etc/chef/rundeck.rb"
 default['rundeck']['chef_client_name'] = "chef-rundeck"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 case node['platform_family']
-when "rhel", "fedora", "suse", "debian", "arch", "freebsd"
+when "arch", "debian", "fedora", "freebsd", "mac_os_x", "rhel", "suse"
   include_recipe 'rundeck::node_unix'   
 when "windows"
   include_recipe 'rundeck::node_windows'  

--- a/recipes/node_unix.rb
+++ b/recipes/node_unix.rb
@@ -25,7 +25,13 @@ if !node['rundeck']['secret_file'].nil? then
   rundeck_secure = Chef::EncryptedDataBagItem.load(node['rundeck']['rundeck_databag'], node['rundeck']['rundeck_databag_secure'], rundeck_secret)
 end  
 
+group node['rundeck']['group'] do
+  system true
+end
+
 user node['rundeck']['user'] do
+  comment 'Rundeck User'
+  gid node['rundeck']['group']
   system true
   shell "/bin/bash"
   home node['rundeck']['basedir']


### PR DESCRIPTION
This PR gives `rundeck` and `rundeck::node_unix` the expected behavior on Mac OS X.
