### PR TITLE
Use latest Chef omnibus

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,8 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: latest
+  chef_omnibus_url: https://www.getchef.com/chef/install.sh
 
 platforms:
   - name: debian-7.4


### PR DESCRIPTION
Currently it fails because chef 11.4.0 doesn't seem to have '-z' option.
The easiest way is just to use the latest chef-omnibus version.

```
% kitchen converge ubuntu
-----> Starting Kitchen (v1.2.1)
-----> Converging <server-ubuntu-1204>...
       Preparing files for transfer
       Resolving cookbook dependencies with Berkshelf 3.1.3...
       Removing non-cookbook files before transfer
       Preparing data bags
       Transfering files to <server-ubuntu-1204>
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-cli-1.3.0/lib/mixlib/cli.rb:226:in `parse_options': invalid option: -z (OptionParser::InvalidOption)
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application.rb:78:in `configure_chef'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application.rb:65:in `reconfigure'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application/client.rb:217:in `reconfigure'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application.rb:71:in `run'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/bin/chef-client:26:in `<top (required)>'
    from /usr/bin/chef-client:23:in `load'
    from /usr/bin/chef-client:23:in `<main>'
>>>>>> Converge failed on instance <server-ubuntu-1204>.
```
