### PR TITLE
Fixes for Red-Hat Family

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,7 +1,5 @@
 DEPENDENCIES
   apt
-  create_chef_dir
-    path: test/fixtures/cookbooks/create_chef_dir
   rundeck
     path: .
     metadata: true
@@ -11,20 +9,24 @@ GRAPH
     iptables (>= 0.0.0)
     logrotate (>= 0.0.0)
     pacman (>= 0.0.0)
-  apt (2.4.0)
+  apt (2.5.3)
   build-essential (2.0.6)
-  create_chef_dir (0.0.1)
-  iptables (0.13.2)
-  java (1.26.0)
+  iptables (0.14.0)
+  java (1.28.0)
   logrotate (1.6.0)
   pacman (1.1.1)
   rundeck (2.0.5)
     apache2 (>= 0.0.0)
     java (>= 0.0.0)
     runit (>= 0.0.0)
+    selinux (>= 0.0.0)
     sudo (>= 0.0.0)
-  runit (1.5.11)
+  runit (1.5.10)
     build-essential (>= 0.0.0)
-    yum (>= 0.0.0)
+    yum (~> 3.0)
+    yum-epel (>= 0.0.0)
+  selinux (0.8.0)
   sudo (2.7.0)
-  yum (3.2.2)
+  yum (3.3.1)
+  yum-epel (0.5.1)
+    yum (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This cookbook relies on multiple data bags. See __Data Bag__ below.
 * Mac OS X (managed node)
 
 **Notes**: This cookbook has been tested on the listed platforms. It may work on other platforms with or without modification.
-
+In RHEL / CentOS , SELinux is enabled by default, it blocks the apache mod_proxy , disable or add an exception selinux
 
 ### Cookbooks
 * Java

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,6 @@ depends          "runit"
 depends          "sudo"
 depends          "java"
 depends          "apache2"
-depends          "selinux"
 
 %w{ debian ubuntu centos suse fedora redhat freebsd windows }.each do |os|
   supports os

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -25,7 +25,6 @@ include_recipe "apache2::mod_headers"
 include_recipe "apache2::mod_ssl"
 include_recipe "apache2::mod_proxy"
 include_recipe "apache2::mod_proxy_http"
-include_recipe "selinux::disabled"
 
 rundeck_secure = data_bag_item(node['rundeck']['rundeck_databag'], node['rundeck']['rundeck_databag_secure'])
 


### PR DESCRIPTION
These corrections can install Rundeck on centos or rhel OS.
Among the corrections are rundeck vhost settings and disable default site of apache.
Disable gpgcheck in yum repo ,since the rpm is not signed.
And finally I disable selinux for the mod_proxy can run.

Run in kitchen with ubuntu 14.04 and there were no errors.

Sorry for my English.
Best Regards
