### PR TITLE
remove unused template variable

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -143,8 +143,7 @@ template "#{node['rundeck']['configdir']}/jaas-activedirectory.conf" do
   source "jaas-activedirectory.conf.erb"
   variables(
     :ldap => node['rundeck']['ldap'],
-    :configdir => node['rundeck']['configdir'],
-    :default_role => node['rundeck']['default_role']
+    :configdir => node['rundeck']['configdir']
   )
   notifies (node['rundeck']['restart_on_config_change'] ? :restart : :nothing), "service[rundeck]", :delayed
 end


### PR DESCRIPTION
This removes the unused template variable 'default_role' from the recipe as it is already copied in the 'ldap' hash (in the attributes). It also enables the cookbook to pass foodcritic.
