### PR TITLE
Fix https redirects when using a reverse proxy

### DIFF
--- a/templates/default/profile.erb
+++ b/templates/default/profile.erb
@@ -31,7 +31,8 @@ export RDECK_JVM="-Djava.security.auth.login.config=<%=@rundeck[:configdir]%>/<%
 	-Drundeck.server.serverDir=<%=@rundeck[:basedir]%> \
 	-Drdeck.projects=<%=@rundeck[:datadir]%>/projects \
 	-Drdeck.runlogs=<%=@rundeck[:basedir]%>/logs \
-	-Drundeck.config.location=<%=@rundeck[:configdir]%>/rundeck-config.properties"
+	-Drundeck.config.location=<%=@rundeck[:configdir]%>/rundeck-config.properties \
+	-Drundeck.jetty.connector.forwarded=true"
 #
 # Set min/max heap size
 #


### PR DESCRIPTION
When using an SSL terminated reverse proxy, users are redirected to a http:// URL during login. Jetty intercepts the request and does not respect the X-Forwarded-Proto header sent by the proxy. 

Add the workaround provided in https://github.com/rundeck/rundeck/issues/732
Support added in Rundeck in this commit: https://github.com/rundeck/rundeck/commit/f1cb0548fa3450f141247f68571dd8d70343c392