### PR TITLE
If forcebindinglogin is true, don't create the bind entries.

### DIFF
--- a/templates/default/jaas-activedirectory.conf.erb
+++ b/templates/default/jaas-activedirectory.conf.erb
@@ -3,8 +3,10 @@ activedirectory {
     debug="true"
     contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
     providerUrl="<%=@ldap[:provider]%>"
+<% unless @ldap[:forcebindinglogin] -%>
     bindDn="<%=@ldap[:binddn]%>"
     bindPassword="<%=@ldap[:bindpwd]%>"
+<% end -%>
     authenticationMethod="<%=@ldap[:authenticationmethod]%>"
     forceBindingLogin="<%=@ldap[:forcebindinglogin]%>"
     userBaseDn="<%=@ldap[:userbasedn]%>"


### PR DESCRIPTION
When working with my LDAP server, I use forcebindinglogin.  However, if I leave the bindDN and bindPassword with the default attributes set, it is still trying to bind with those creds instead of the user creds.  Just added an unless block to clean this up.