### PR TITLE
Add option to use a webcontext other than '/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Linux default attributes for all rundeck managed nodes and server
 * `node['rundeck']['cert']['name']` - SSL certificate name. Certificate files should be named this .key and .crt, default node['rundeck']['hostname']
 * `node['rundeck']['cert']['ca_name']` - SSL CA certificate name. If this and use_ssl are set, a certificate authority file is used in the apache vhost. CA certificate files should be named this .crt, default 'nil'
 * `node['rundeck']['cert']['cookbook']` - The cookbook to copy the SSL certificates from, default 'rundeck'
-* `node['rundeck']['server_url']` - The URL of the rundeck server, default 'http://#{node['rundeck']['hostname']}', or 'https://#{node['rundeck']['hostname']}' if use_ssl is set.
+* `node['rundeck']['webcontext']` - The URI portion of the rundeck server, default '/', you can set it to '/rundeck' if your webserver is handling other tasks besides rundeck.
+* `node['rundeck']['server_url']` - The URL of the rundeck server, default 'http://#{node['rundeck']['hostname']}#{node['rundeck']['webcontext']}', or 'https://#{node['rundeck']['hostname']}#{node['rundeck']['webcontext']}' if use_ssl is set.
 
 Windows default attributes for all rundeck managed nodes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,8 @@ default['rundeck']['apache-template']['cookbook'] = 'rundeck'
 default['rundeck']['use_ssl'] = false
 default['rundeck']['cert']['name'] = node['rundeck']['hostname']
 default['rundeck']['cert']['cookbook'] = 'rundeck'
-default['rundeck']['server_url'] = "#{node['rundeck']['use_ssl'] ? 'https' : 'http'}://#{node['rundeck']['hostname']}"
+default['rundeck']['webcontext'] = '/'
+default['rundeck']['server_url'] = "#{node['rundeck']['use_ssl'] ? 'https' : 'http'}://#{node['rundeck']['hostname']}/#{node['rundeck']['webcontext']}"
 
 default['rundeck']['log_level'] = 'DEBUG' # ERR,WARN,INFO,VERBOSE,DEBUG
 default['rundeck']['rss_enabled'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['rundeck']['use_ssl'] = false
 default['rundeck']['cert']['name'] = node['rundeck']['hostname']
 default['rundeck']['cert']['cookbook'] = 'rundeck'
 default['rundeck']['webcontext'] = '/'
-default['rundeck']['server_url'] = "#{node['rundeck']['use_ssl'] ? 'https' : 'http'}://#{node['rundeck']['hostname']}/#{node['rundeck']['webcontext']}"
+default['rundeck']['server_url'] = "#{node['rundeck']['use_ssl'] ? 'https' : 'http'}://#{node['rundeck']['hostname']}#{node['rundeck']['webcontext']}"
 
 default['rundeck']['log_level'] = 'DEBUG' # ERR,WARN,INFO,VERBOSE,DEBUG
 default['rundeck']['rss_enabled'] = true

--- a/templates/default/profile.erb
+++ b/templates/default/profile.erb
@@ -32,6 +32,7 @@ export RDECK_JVM="-Djava.security.auth.login.config=<%=@rundeck[:configdir]%>/<%
 	-Drdeck.projects=<%=@rundeck[:datadir]%>/projects \
 	-Drdeck.runlogs=<%=@rundeck[:basedir]%>/logs \
 	-Drundeck.config.location=<%=@rundeck[:configdir]%>/rundeck-config.properties \
+	-Dserver.web.context=<%=@rundeck[:webcontext]%> \
 	-Drundeck.jetty.connector.forwarded=true"
 #
 # Set min/max heap size

--- a/templates/default/rundeck.conf.erb
+++ b/templates/default/rundeck.conf.erb
@@ -29,8 +29,8 @@
                 Allow from all
         </Proxy>
         
-        ProxyPass        / http://localhost:<%= node['rundeck']['port'] %>/
-        ProxyPassReverse / http://localhost:<%= node['rundeck']['port'] %>/
+        ProxyPass        <%= node['rundeck']['webcontext'] %> http://localhost:<%= node['rundeck']['port'] %><%= node['rundeck']['webcontext'] %>
+        ProxyPassReverse <%= node['rundeck']['webcontext'] %> http://localhost:<%= node['rundeck']['port'] %><%= node['rundeck']['webcontext'] %>
         
         <Directory />
                 Options FollowSymLinks


### PR DESCRIPTION
This is useful if the apache server is not dedicated to rundeck, so instead of http://hostname, we can use http://hostname/rundeck if you set webcontext = '/rundeck'.