### PR TITLE
Fixes missing 'yum_repository' resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ depends          'runit'
 depends          'sudo'
 depends          'java'
 depends          'apache2'
-recommends       'yum'
+depends          'yum'
 
 %w(debian ubuntu centos suse fedora redhat freebsd windows).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ depends          'runit'
 depends          'sudo'
 depends          'java'
 depends          'apache2'
+recommends       'yum'
 
 %w(debian ubuntu centos suse fedora redhat freebsd windows).each do |os|
   supports os


### PR DESCRIPTION
When provisioning the rundeck::server recipe on rpm based systems, the following error is receieved:
    No resource or method named `yum_repository' for `Chef::Recipe "server"'
This is fixed by adding the 'yum' cookbook as a dependency.