### PR TITLE
Using remote_file instead of cookbook_file for installation of slack plugin

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -278,8 +278,9 @@ bags.each do |project|
 end
 
 # Plugins
-cookbook_file node['rundeck']['plugin']['slack'] do
-  path "/var/lib/rundeck/libext/rundeck-slack-incoming-webhook-plugin.jar"
+remote_file  'rundeck-slack-incoming-webhook-plugin' do
+  source "#{node['rundeck']['plugin']['slack']}"
+  path "#{node['rundeck']['basedir']}/libext/rundeck-slack-incoming-webhook-plugin.jar"
   owner node['rundeck']['user']
   group node['rundeck']['group']
   action :create

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -279,7 +279,7 @@ end
 
 # Plugins
 remote_file  'rundeck-slack-incoming-webhook-plugin' do
-  source "#{node['rundeck']['plugin']['slack']}"
+  source node['rundeck']['plugin']['slack']
   path "#{node['rundeck']['basedir']}/libext/rundeck-slack-incoming-webhook-plugin.jar"
   owner node['rundeck']['user']
   group node['rundeck']['group']


### PR DESCRIPTION
We are downloading the jar from a remote location (node['rundeck]['plugin']['slack']) and cookbook_file is searching for the file locally inside COOKBOOK/files/default directory causing chef run to fail.