### PR TITLE
Made some rundeck framework properties configurable.

### DIFF
--- a/templates/default/framework.properties.erb
+++ b/templates/default/framework.properties.erb
@@ -163,15 +163,15 @@ framework.centraldispatcher.classname = com.dtolabs.client.services.RundeckAPICe
 #
 framework.server.username = admin
 framework.server.password = <%= (@rundeck_users['admin']['password'] rescue nil) || 'admin' %>
-framework.server.hostname = localhost
-framework.server.name = localhost
+framework.server.hostname = <%= @rundeck[:hostname] %>
+framework.server.name = <%= node.hostname %>
 framework.server.port = 4440
-framework.server.url = http://localhost:4440
+framework.server.url = http://<%= @rundeck[:hostname] %>:4440
 
 #
 # URL to Rundeck
 #
-framework.rundeck.url = http://localhost:4440
+framework.rundeck.url = http://<%= @rundeck[:hostname] %>:4440
 
 #
 # ssh keypath

--- a/templates/default/framework.properties.erb
+++ b/templates/default/framework.properties.erb
@@ -165,13 +165,13 @@ framework.server.username = admin
 framework.server.password = <%= (@rundeck_users['admin']['password'] rescue nil) || 'admin' %>
 framework.server.hostname = <%= @rundeck[:hostname] %>
 framework.server.name = <%= node.hostname %>
-framework.server.port = 4440
-framework.server.url = http://<%= @rundeck[:hostname] %>:4440
+framework.server.port = <%= @rundeck[:port] %>
+framework.server.url = http://<%= @rundeck[:hostname] %>:<%= @rundeck[:port] %>
 
 #
 # URL to Rundeck
 #
-framework.rundeck.url = http://<%= @rundeck[:hostname] %>:4440
+framework.rundeck.url = http://<%= @rundeck[:hostname] %>:<%= @rundeck[:port] %>
 
 #
 # ssh keypath

--- a/templates/default/framework.properties.erb
+++ b/templates/default/framework.properties.erb
@@ -39,6 +39,15 @@ framework.email.password = <%= @rundeck[:mail][:password] %>
 framework.email.ssl = false
 framework.email.failonerror = true
 
+
+#
+# Custom config
+#
+#
+<% node.rundeck[:custom_framework_config].sort.each do |key, value| %>
+<%= key %>=<%= value %>
+<% end %>
+
 # ----------------------------------------------------------------
 # Do not make changes below this line
 # ----------------------------------------------------------------

--- a/templates/default/framework.properties.erb
+++ b/templates/default/framework.properties.erb
@@ -44,7 +44,7 @@ framework.email.failonerror = true
 # Custom config
 #
 #
-<% node.rundeck[:custom_framework_config].sort.each do |key, value| %>
+<% node.rundeck['custom_framework_config'].sort.each do |key, value| %>
 <%= key %>=<%= value %>
 <% end %>
 


### PR DESCRIPTION
This will allow us to set the rundeck server URL and the rundeck URL with the FQDN of the rundeck server. Otherwise once we login to the web console it will redirect to http://localhost:4440 which will obviously not work.