### PR TITLE
chef-rundeck systemd unit file syntax fix

### DIFF
--- a/templates/default/chef-rundeck-systemd.conf.erb
+++ b/templates/default/chef-rundeck-systemd.conf.erb
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 User=<%=@user%>
-ExecStart="/opt/chef/embedded/bin/chef-rundeck -c <%=@chef_config%> -f <%=@project_config%> -w <%=@chef_webui_url%> -o <%=@chef_rundeck_host%> -p <%=@chef_rundeck_port%> -u <%= node['rundeck']['user'] %> -t <%= @chef_rundeck_cachetime %> <% if @chef_rundeck_partial_search %>--partial-search true<% end %> 2>&1 > <%=@log_dir%>/server.log"
+ExecStart=/opt/chef/embedded/bin/chef-rundeck -c <%=@chef_config%> -f <%=@project_config%> -w <%=@chef_webui_url%> -o <%=@chef_rundeck_host%> -p <%=@chef_rundeck_port%> -u <%= node['rundeck']['user'] %> -t <%= @chef_rundeck_cachetime %> <% if @chef_rundeck_partial_search %>--partial-search true<% end %> 2>&1 > <%=@log_dir%>/server.log
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
On Debian 8 and thus systemd for chef-rundeck, I get the following error

```
[/etc/systemd/system/chef-rundeck.service:9] Executable path is not absolute, ignoring: "/opt/chef/embedded/bin/chef-rundeck -c /etc/chef/rundeck.rb -f /etc/chef/chef-rundeck....ndeck/server.log"
chef-rundeck.service lacks ExecStart setting. Refusing.
```

Dropping the quotes around the ExecStart command resolves it.

`rundeck systemd[1]: Started Chef Rundeck service.`