### PR TITLE
Added an attribute to configure Quartz job threadCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Active Directory/LDAP Attributes
 * `node['rundeck']['ldap']['reportstatistics']` - If true, output cache statistics to the log
 * `node['rundeck]['ldap]['debug']` - If true, output debug logs related to ldap to rundeck service.log. Default is true.
 
+Quartz Configuration
+
+* `node['rundeck']['quartz']['threadPoolCount']` - Quartz job threadCount. The maximum number of threads used by Rundeck for concurrent jobs by default is set to 10.
+
 Recipes
 -------
 ### default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,9 @@ default['rundeck']['rss_enabled'] = true
 # java configuration
 default['rundeck']['jvm_mem'] = ' -XX:MaxPermSize=256m -Xmx1024m -Xms256m'
 
+# Quartz configuration.
+default['rundeck']['quartz']['threadPoolCount'] = 10
+
 # login session timeout
 default['rundeck']['session_timeout'] = 30
 

--- a/templates/default/rundeck-config.properties.erb
+++ b/templates/default/rundeck-config.properties.erb
@@ -33,3 +33,5 @@ grails.mail.port=<%=@rundeck[:mail][:port] %>
 grails.mail.default.from=<%=@rundeck[:email] %>
 
 grails.serverURL=<%= node['rundeck']['grails_server_url']%><% unless [80,443].include?(node['rundeck']['grails_port'])%>:<%=node['rundeck']['grails_port'].to_s%><% end %>
+
+quartz.props.threadPool.threadCount = <%= @rundeck[:quartz][:threadPoolCount].to_i %>


### PR DESCRIPTION
Quartz Job ThreadCounf is used to define the number of threads that rundeck will use to run parallel jobs. The default value is 10.