### PR TITLE
Add default version property for jdk7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,7 @@ default['rundeck']['rss_enabled'] = true
 
 # java configuration
 default['rundeck']['jvm_mem'] = ' -XX:MaxPermSize=256m -Xmx1024m -Xms256m'
+default['java']['jdk_version'] = '7'
 
 # Quartz configuration.
 default['rundeck']['quartz']['threadPoolCount'] = 10


### PR DESCRIPTION
Adding a default property for Java 7 as this has been required in recent versions of rundeck.

See #87 