### PR TITLE
Support Auto Install of Arbitrary node['rundeck']['plugin'] Children

### DIFF
--- a/recipes/server_install.rb
+++ b/recipes/server_install.rb
@@ -222,10 +222,12 @@ bags.each do |project|
 end
 
 # Plugins
-remote_file 'rundeck-slack-incoming-webhook-plugin' do
-  source node['rundeck']['plugin']['slack']
-  path "#{node['rundeck']['basedir']}/libext/rundeck-slack-incoming-webhook-plugin.jar"
-  owner node['rundeck']['user']
-  group node['rundeck']['group']
-  action :create
+node['rundeck']['plugin'].each_key do |key|
+  remote_file "rundeck-#{key}-plugin" do
+    source node['rundeck']['plugin'][key]
+    path "#{node['rundeck']['basedir']}/libext/rundeck-#{key}-plugin.jar"
+    owner node['rundeck']['user']
+    group node['rundeck']['group']
+    action :create
+  end
 end


### PR DESCRIPTION
Modified plugin remote_file resource to support iteration over all child attributes of node['rundeck']['plugin']. This allows arbitrary installation of any plugin simply by adding it as an attribute.

E.g.:
`normal[:rundeck][:plugin][:hipchat] = 'http://search.maven.org/remotecontent?filepath=com/hbakkum/rundeck/plugins/rundeck-hipchat-plugin/1.6.0/rundeck-hipchat-plugin-1.6.0.jar'`