### PR TITLE
Changing rdbms default from string to boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Distribute to all systems that will work with rundeck via a recipe and set the p
 
 * `node['rundeck']['secret_file']` - default 'nil'
 
-* `node['rundeck']['rdbms']['enable']` - enable RDBMS support, default 'false'
+* `node['rundeck']['rdbms']['enable']` - enable RDBMS support, default false
 * `node['rundeck']['rdbms']['type']` - database type, default 'mysql'
 
 Common RDBMS Configuration

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -97,7 +97,7 @@ default['rundeck']['mail']['password'] = ''
 default['rundeck']['secret_file'] = nil
 
 # External Database properties
-default['rundeck']['rdbms']['enable'] = 'false'
+default['rundeck']['rdbms']['enable'] = false
 default['rundeck']['rdbms']['type'] = 'mysql'
 default['rundeck']['rdbms']['location'] = 'someIPorFQDN'
 default['rundeck']['rdbms']['dbname'] = 'rundeckdb'

--- a/templates/default/rundeck-config.properties.erb
+++ b/templates/default/rundeck-config.properties.erb
@@ -4,7 +4,7 @@ loglevel.default=<%= node['rundeck']['log_level'] %>
 #rss.enabled if set to true enables RSS feeds that are public (non-authenticated)
 rss.enabled=<%= node['rundeck']['rss_enabled'] %>
 #
-<% if @rundeck[:rdbms][:enable] == 'true' %>
+<% if @rundeck[:rdbms][:enable] %>
   <% if @rundeck[:rdbms][:type] == 'mysql' %>
 dataSource.url = jdbc:mysql://<%= @rundeck[:rdbms][:location] %>:<%= @rundeck[:rdbms][:port] %>/<%= @rundeck[:rdbms][:dbname] %>?autoReconnect=true
 dataSource.driverClassName=com.mysql.jdbc.Driver
@@ -16,9 +16,7 @@ dataSource.dialect = org.hibernate.dialect.<%= @rundeck[:rdbms][:dialect] %>
 dataSource.dbCreate=update
 dataSource.username = <%= @rundeck_rdbms['dbuser'] %>
 dataSource.password = <%= @rundeck_rdbms['dbpassword'] %>
-<% end %>
-
-<% if @rundeck[:rdbms][:enable] == false %>
+<% else %>
 dataSource.url = jdbc:hsqldb:file:/var/lib/rundeck/data/grailsdb;shutdown=true
 <% end %>
 

--- a/test/integration/default/serverspec/localhost/server_install_spec.rb
+++ b/test/integration/default/serverspec/localhost/server_install_spec.rb
@@ -74,7 +74,8 @@ describe file('/etc/rundeck/rundeck-config.properties') do
   it { should exist }
   it { should be_owned_by 'rundeck' }
   it { should be_grouped_into 'rundeck' }
-  it { should_not contain(%r{dataSource.url=jdbc:mysql://someIPorFQDN:3306/rundeckdb?autoReconnect=true}) }
+  it { should contain(%r{dataSource.url = jdbc:hsqldb:file:/var/lib/rundeck/data/grailsdb;shutdown=true}) }
+  it { should_not contain(%r{dataSource.url = jdbc:mysql://someIPorFQDN:3306/rundeckdb?autoReconnect=true}) }
   it { should_not contain(/dataSource.username = \w/) }
   it { should_not contain(/dataSource.password = \w/) }
 end


### PR DESCRIPTION
* Changed string to boolean value false in `attributes/default.rb` and README
* Changed the logic in `templates/default/rundeck-config.properties.erb` to support boolean values
* Added tests

Fixes: #118

I think this would be a breaking change for some people. If you want to make a 4.x branch I can open a PR to that instead.