### PR TITLE
always returns an authenticated api client

### DIFF
--- a/libraries/rundeck_api_client.rb
+++ b/libraries/rundeck_api_client.rb
@@ -3,10 +3,14 @@ require 'net/http'
 require 'openssl'
 
 class RundeckApiClient
-  def initialize(rundeck_server_url, user, opts={})
+  def initialize(rundeck_server_url, user, pass, opts={})
     @rundeck_server_url, @user, = rundeck_server_url, user
+
     # convert all opts keys to symbols
     @opts = opts.each_with_object({}) { |(k,v), h| h[k.to_sym] = v }
+
+    # the api only responds to authenticated clients, so call it from the constructor
+    authenticate(pass)
   end
 
   # POST auth GET params to auth endpoint

--- a/test/integration/default/serverspec/localhost/rundeck_api_client_spec.rb
+++ b/test/integration/default/serverspec/localhost/rundeck_api_client_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 describe RundeckApiClient do
   let(:client) do
-    client = described_class.new('http://localhost', 'admin')
-    client.authenticate('adminpassword')
-    client
+    described_class.new('http://localhost', 'admin', 'adminpassword')
   end
 
   it 'correctly reads the rundeck server api version' do


### PR DESCRIPTION
cant do anything with rundeck api without authentication, so just call `#authenticate` from `#initialize`

*not yet ready for review / merge*