### PR TITLE
RundeckApiClient#connect to get an authenticated api client

### DIFF
--- a/libraries/rundeck_api_client.rb
+++ b/libraries/rundeck_api_client.rb
@@ -20,6 +20,15 @@ class RundeckApiClient
     send_req(req)
   end
 
+  # wrapper around constructor and authentication
+  # nothing can be done via the api without authenticating, so this method is
+  # the preferred way to initialize a client
+  def self.connect(rundeck_server_url, user, pass, opts={})
+    client = new(rundeck_server_url, user, opts)
+    client.authenticate(pass)
+    client
+  end
+
   def prep_req(req)
     req['User-Agent'] = 'RundeckApiClient'
     req['Content-Type'] = 'application/json'

--- a/test/integration/default/serverspec/localhost/rundeck_api_client_spec.rb
+++ b/test/integration/default/serverspec/localhost/rundeck_api_client_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 describe RundeckApiClient do
   let(:client) do
-    client = described_class.new('http://localhost', 'admin')
-    client.authenticate('adminpassword')
-    client
+    described_class.connect('http://localhost', 'admin', 'adminpassword')
   end
 
   it 'correctly reads the rundeck server api version' do


### PR DESCRIPTION
adds a wrapper around the constructor method and the authenticate method to get an authenticated api client

replaces #131 