### PR TITLE
use build-essential default recipe rather than calling lwrp

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
+default['build-essential']['compile_time'] = true
+
 default['rundeck']['configdir'] = '/etc/rundeck'
 default['rundeck']['basedir'] = '/var/lib/rundeck'
 default['rundeck']['datadir'] = '/var/rundeck'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'Peter Crossley <peter.crossley@webtrends.com>'
 license          'All rights reserved'
 description      'Installs and configures Rundeck 2.x'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.0.0'
+version          '4.0.1'
 depends          'runit'
 depends          'sudo'
 depends          'java'

--- a/recipes/_connect_rundeck_api_client.rb
+++ b/recipes/_connect_rundeck_api_client.rb
@@ -1,8 +1,6 @@
 # rest-client gem is needed for api client library
 # install at compile time so library can be used as soon as needed
-build_essential 'install packages' do
-  compile_time true
-end
+include_recipe 'build-essential'
 chef_gem 'rest-client' do
   compile_time true
   version '~> 2.0'

--- a/spec/recipes/connect_api_client_spec.rb
+++ b/spec/recipes/connect_api_client_spec.rb
@@ -6,7 +6,8 @@ describe 'rundeck::_connect_rundeck_api_client' do
   end
 
   it 'installs dependencies' do
-    expect(chef_run).to install_build_essential('install packages').with(
+    expect(chef_run).to include_recipe 'build-essential'
+    expect(chef_run).to install_build_essential('install_packages').with(
       compile_time: true
     )
     expect(chef_run).to install_chef_gem('rest-client').with(


### PR DESCRIPTION
this is for supporting older versions of build-essential cookbook that do not publish an lwrp