### PR TITLE
added failing spec for request_defaults merging

### DIFF
--- a/libraries/rundeck_api_client.rb
+++ b/libraries/rundeck_api_client.rb
@@ -29,7 +29,8 @@ class RundeckApiClient
   #     'http://localhost:80',
   #     'admin',
   #     'adminpassword',
-  #     log_level: 0
+  #     log_level: 0,
+  #     request_defaults: { verify_ssl: false }
   #   )
   def self.connect(server_url, username, password, opts={})
     client = new(server_url, username, opts)
@@ -135,7 +136,7 @@ class RundeckApiClient
         'Content-Type' => 'application/json',
         'User-Agent' => self.class.name
       }
-    }.deep_merge(@config['request_defaults'].to_h)
+    }.deep_merge(@config[:request_defaults].to_h)
   end
 
   def logger

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'Peter Crossley <peter.crossley@webtrends.com>'
 license          'All rights reserved'
 description      'Installs and configures Rundeck 2.x'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.0.1'
+version          '4.0.2'
 depends          'runit'
 depends          'sudo'
 depends          'java'

--- a/spec/libraries/rundeck_api_client_spec.rb
+++ b/spec/libraries/rundeck_api_client_spec.rb
@@ -62,14 +62,26 @@ describe RundeckApiClient do
       let(:client) { described_class.new(server_url, 'username') }
 
       it "returns the client's default request options" do
-        expect(client.request_defaults).to eq({
+        expect(client.request_defaults).to eq(
           cookies: nil,
           headers: {
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
             'User-Agent' => described_class.name
           }
-        })
+        )
+      end
+
+      it 'merges with options provided' do
+        expect(client.request_defaults(verify_ssl: false)).to eq(
+          cookies: nil,
+          headers: {
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'User-Agent' => described_class.name
+          },
+          verify_ssl: false
+        )
       end
     end
 

--- a/spec/libraries/rundeck_api_client_spec.rb
+++ b/spec/libraries/rundeck_api_client_spec.rb
@@ -1,14 +1,28 @@
 require 'spec_helper'
 
+describe Hash do
+  describe '#deep_merge' do
+    let(:hsh) { { a: 'A', b: { 'c' => 'C', 'd' => 'D' } } }
+    it 'merges deeply' do
+      expect(hsh.deep_merge(
+        b: { 'd' => 'd', 'e' => 'e' },
+        f: 'f'
+      )).to eq(
+        a: 'A',
+        b: { 'c' => 'C', 'd' => 'd', 'e' => 'e' },
+        f: 'f'
+      )
+    end
+  end
+end
+
 describe RundeckApiClient do
   let(:server_url) { 'https://rundeck.domain.com' }
   let(:client) do
     described_class.new(
       server_url,
       'username',
-      {
-        'request_defaults' => { 'verify_mode' => 0 }
-      }
+      'request_defaults' => { verify_ssl: false }
     )
   end
 
@@ -17,7 +31,7 @@ describe RundeckApiClient do
       expect_any_instance_of(described_class).to receive(:require).with('rest-client')
       expect(client.instance_variable_get('@server_url')).to eq(server_url)
       expect(client.instance_variable_get('@config')).to eq(
-        { request_defaults: { 'verify_mode' => 0 } }
+        request_defaults: { verify_ssl: false }
       )
       expect(client).to be_an_instance_of(described_class)
     end
@@ -71,18 +85,6 @@ describe RundeckApiClient do
           }
         )
       end
-
-      it 'merges with options provided' do
-        expect(client.request_defaults(verify_ssl: false)).to eq(
-          cookies: nil,
-          headers: {
-            'Accept' => 'application/json',
-            'Content-Type' => 'application/json',
-            'User-Agent' => described_class.name
-          },
-          verify_ssl: false
-        )
-      end
     end
 
     context 'request defaults provided in client initialization' do
@@ -93,7 +95,8 @@ describe RundeckApiClient do
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
             'User-Agent' => described_class.name
-          }
+          },
+          verify_ssl: false
         })
       end
     end
@@ -107,7 +110,8 @@ describe RundeckApiClient do
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
             'User-Agent' => described_class.name
-          }
+          },
+          verify_ssl: false
         })
       end
     end


### PR DESCRIPTION
verify_ssl is the proper key to use with rest-client: https://github.com/rest-client/rest-client/blob/8874463a44ec6d5a702b7c9d4cc7c392bba80e0c/lib/restclient/request.rb#L99

when this was set in the initialization of the client it wasnt getting sent with every request

this should fix that