### PR TITLE
symbolize all keys in config hash

### DIFF
--- a/libraries/rundeck_api_client.rb
+++ b/libraries/rundeck_api_client.rb
@@ -8,6 +8,16 @@ class Hash
     end
     self.merge(second, &merger)
   end
+
+  def symbolize_all_keys
+    symbolized_hash = {}
+    self.each do |k, v|
+      key = k.respond_to?(:to_sym) ? k.to_sym : k
+      value = v.is_a?(Hash) ? v.symbolize_all_keys : v
+      symbolized_hash[key] = value
+    end
+    symbolized_hash
+  end
 end
 
 class RundeckApiClient
@@ -19,7 +29,7 @@ class RundeckApiClient
     @server_url, @username = server_url, username
 
     # convert all config keys to symbols
-    @config = config.each_with_object({}) { |(k,v), h| h[k.to_sym] = v }
+    @config = config.symbolize_all_keys
   end
 
   # @return [RundeckApiClient] an authenticated client

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'Peter Crossley <peter.crossley@webtrends.com>'
 license          'All rights reserved'
 description      'Installs and configures Rundeck 2.x'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.0.2'
+version          '4.0.3'
 depends          'runit'
 depends          'sudo'
 depends          'java'

--- a/spec/libraries/rundeck_api_client_spec.rb
+++ b/spec/libraries/rundeck_api_client_spec.rb
@@ -14,6 +14,36 @@ describe Hash do
       )
     end
   end
+
+  describe '#symbolize_all_keys' do
+    let(:hsh) do
+      {
+        'a' => true,
+        'b' => {},
+        'c' => {
+          false => 4,
+          d: 'D',
+          'e' => { 'a' => 'b' }
+        },
+        d: 'blue',
+        'e' => 'green'
+      }
+    end
+
+    it 'symbolizes all keys recursively' do
+      expect(hsh.symbolize_all_keys).to eq(
+        a: true,
+        b: {},
+        c: {
+          false => 4,
+          d: 'D',
+          e: { a: 'b' }
+        },
+        d: 'blue',
+        e: 'green'
+      )
+    end
+  end
 end
 
 describe RundeckApiClient do


### PR DESCRIPTION
this is unfortunately necessary so that keys passed in the request_defaults are symbols so that rest-client sees `:verify_ssl` rather than `'verify_ssl'`